### PR TITLE
Add network policy label

### DIFF
--- a/pkg/virtualgarden/kube_api_server_deployments.go
+++ b/pkg/virtualgarden/kube_api_server_deployments.go
@@ -81,16 +81,17 @@ func (o *operation) deployKubeAPIServerDeployment(ctx context.Context, checksums
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: annotations,
 					Labels: map[string]string{
-						LabelKeyApp:                                                  Prefix,
-						LabelKeyComponent:                                            "kube-apiserver",
-						"networking.gardener.cloud/to-dns":                           LabelValueAllowed,
-						"networking.gardener.cloud/to-etcd":                          LabelValueAllowed,
-						"networking.gardener.cloud/to-gardener-apiserver":            LabelValueAllowed,
-						"networking.gardener.cloud/to-gardener-admission-controller": LabelValueAllowed, // needed for webhooks
-						"networking.gardener.cloud/to-identity":                      LabelValueAllowed,
-						"networking.gardener.cloud/to-ingress":                       LabelValueAllowed, // needed for communication to identity
-						"networking.gardener.cloud/to-terminal-controller-manager":   LabelValueAllowed, // needed for webhooks
-						"networking.gardener.cloud/to-world":                         LabelValueAllowed, // GCP puts IP tables on nodes that allow for local routing, for other cloudproviders this is needed
+						LabelKeyApp:                                                   Prefix,
+						LabelKeyComponent:                                             "kube-apiserver",
+						"networking.gardener.cloud/to-dns":                            LabelValueAllowed,
+						"networking.gardener.cloud/to-etcd":                           LabelValueAllowed,
+						"networking.gardener.cloud/to-gardener-apiserver":             LabelValueAllowed,
+						"networking.gardener.cloud/to-gardener-admission-controller":  LabelValueAllowed, // needed for webhooks
+						"networking.gardener.cloud/to-identity":                       LabelValueAllowed,
+						"networking.gardener.cloud/to-ingress":                        LabelValueAllowed, // needed for communication to identity
+						"networking.gardener.cloud/to-terminal-controller-manager":    LabelValueAllowed, // needed for webhooks
+						"networking.gardener.cloud/to-gardenlogin-controller-manager": LabelValueAllowed, // needed for webhooks
+						"networking.gardener.cloud/to-world":                          LabelValueAllowed, // GCP puts IP tables on nodes that allow for local routing, for other cloudproviders this is needed
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/virtualgarden/resources/audit_policy.yaml
+++ b/pkg/virtualgarden/resources/audit_policy.yaml
@@ -35,6 +35,7 @@ rules:
       - system:serviceaccount:garden:gardener-scheduler
       - system:serviceaccount:garden:secret-binding-distributor
       - system:serviceaccount:terminal-system:default
+      - system:serviceaccount:gardenlogin-system:gardenlogin-controller-manager
       - virtual-garden:client:admin
       - vpn-seed
   - level: None


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
This PR adds the network policy label to the virtual garden kube-apiserver deployment.

**Which issue(s) this PR fixes**:
Fixes #12 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
