### PR TITLE
Harmoninze blueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,13 @@
 /.kube-secrets
 /tmp/*
 /local
+/gen
 **/dev
 
 *.coverprofile
 *.html
 .vscode
+.cache_ggshield
 .idea
 .DS_Store
 *~

--- a/.landscaper/blueprint/blueprint.yaml
+++ b/.landscaper/blueprint/blueprint.yaml
@@ -2,11 +2,11 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Blueprint
 
 imports:
-  - name: cluster
+  - name: runtimeCluster
     required: true
     targetType: landscaper.gardener.cloud/kubernetes-cluster
 
-  - name: hostingCluster
+  - name: runtimeClusterSettings
     schema:
       type: object
       properties:
@@ -242,7 +242,7 @@ imports:
           type: string
 
 exports:
-- name: kubeApiserverCaPem
+- name: virtualGardenApiserverCaPem
   schema:
     type: string
 
@@ -262,7 +262,12 @@ exports:
   schema:
     type: string
 
-- name: virtualGardenKubeconfig
+- name: etcdUrl
+  schema:
+    type: string
+
+- name: virtualGardenCluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 
 - name: virtualGardenEndpoint

--- a/.landscaper/blueprint/virtual-garden-deploy-execution.yaml
+++ b/.landscaper/blueprint/virtual-garden-deploy-execution.yaml
@@ -2,8 +2,8 @@ deployItems:
 - name: virtual-garden-container-deployer
   type: landscaper.gardener.cloud/container
   target:
-    name: {{ index .imports "cluster" "metadata" "name" }}
-    namespace: {{ index .imports "cluster" "metadata" "namespace" }}
+    name: {{ index .imports "runtimeCluster" "metadata" "name" }}
+    namespace: {{ index .imports "runtimeCluster" "metadata" "namespace" }}
   config:
     apiVersion: container.deployer.landscaper.gardener.cloud/v1alpha1
     kind: ProviderConfiguration

--- a/.landscaper/blueprint/virtual-garden-export-execution.yaml
+++ b/.landscaper/blueprint/virtual-garden-export-execution.yaml
@@ -17,7 +17,7 @@ exports:
   virtualGardenEndpoint: |
     {{- index .values "deployitems" "virtual-garden-container-deployer" "virtualGardenEndpoint" | nindent 4 }}
 
-  virtual-garden-cluster:
+  virtualGardenCluster:
     type: landscaper.gardener.cloud/kubernetes-cluster
     config:
       kubeconfig: |

--- a/.landscaper/blueprint/virtual-garden-export-execution.yaml
+++ b/.landscaper/blueprint/virtual-garden-export-execution.yaml
@@ -1,6 +1,6 @@
 exports:
-  kubeApiserverCaPem: |
-    {{- index .values "deployitems" "virtual-garden-container-deployer" "kubeApiserverCaPem" | nindent 4 }}
+  virtualGardenApiserverCaPem: |
+    {{- index .values "deployitems" "virtual-garden-container-deployer" "virtualGardenApiserverCaPem" | nindent 4 }}
 
   etcdCaPem: |
     {{- index .values "deployitems" "virtual-garden-container-deployer" "etcdCaPem" | nindent 4 }}
@@ -11,10 +11,13 @@ exports:
   etcdClientTlsKeyPem: |
     {{- index .values "deployitems" "virtual-garden-container-deployer" "etcdClientTlsKeyPem" | nindent 4 }}
 
+  etcdUrl: |
+    {{- index .values "deployitems" "virtual-garden-container-deployer" "etcdUrl" | nindent 4 }}
+
   virtualGardenEndpoint: |
     {{- index .values "deployitems" "virtual-garden-container-deployer" "virtualGardenEndpoint" | nindent 4 }}
 
-  virtualGardenKubeconfig:
+  virtual-garden-cluster:
     type: landscaper.gardener.cloud/kubernetes-cluster
     config:
       kubeconfig: |

--- a/cmd/virtual-garden/app/virtual_garden.go
+++ b/cmd/virtual-garden/app/virtual_garden.go
@@ -116,12 +116,12 @@ func run(ctx context.Context, log *logrus.Logger, opts *Options) error {
 	}
 
 	log.Infof("Creating REST config and Kubernetes client based on given kubeconfig")
-	client, err := NewClientFromTarget(imports.Cluster)
+	client, err := NewClientFromTarget(imports.RuntimeCluster)
 	if err != nil {
 		return err
 	}
 
-	operation, err := virtualgarden.NewOperation(client, log, imports.HostingCluster.Namespace, imports, imageRefs)
+	operation, err := virtualgarden.NewOperation(client, log, imports.RuntimeClusterSettings.Namespace, imports, imageRefs)
 	if err != nil {
 		return err
 	}

--- a/docs/deploy-virtual-garden-with-landscaper.md
+++ b/docs/deploy-virtual-garden-with-landscaper.md
@@ -35,7 +35,7 @@ The component descriptor contains the list of all resources required for the dep
 
 - the blueprint,  
 - the image from the previous step, which will be executed by the container deployer,  
-- the images of etcd, kube-apiserver, etc. which will be deployed to the host cluster of the virtual garden.  
+- the images of etcd, kube-apiserver, etc. which will be deployed to the runtime cluster of the virtual garden.  
 
 ### Creating a Target and an Installation
 

--- a/example/imports.yaml
+++ b/example/imports.yaml
@@ -1,4 +1,4 @@
-cluster:
+runtimeCluster:
   apiVersion: landscaper.gardener.cloud/v1alpha1
   kind: Target
   spec:
@@ -7,7 +7,7 @@ cluster:
       kubeconfig: |
       #       ... <please insert your kubeconfig here>
 
-hostingCluster:
+runtimeClusterSettings:
   namespace: garden
   infrastructureProvider: gcp
 

--- a/hack/create-installation.sh
+++ b/hack/create-installation.sh
@@ -40,13 +40,14 @@ spec:
 
   imports:
     targets:
-    - name: cluster
-      target: "#cluster"
+    - name: runtimeCluster
+      target: "#runtime-cluster"
 
+  # static data to not require to import config map
   importDataMappings:
-    hostingCluster:
+    runtimeClusterSettings:
       namespace: garden
-      infrastructureProvider: gcp
+      infrastructureProvider: aws
 
     virtualGarden:
       deleteNamespace: true
@@ -62,20 +63,22 @@ spec:
 
   exports:
     data:
-    - name: kubeApiserverCaPem
-      dataRef: "kubeapiservercapem"
+    - name: virtualGardenApiserverCaPem
+      dataRef: "virtual-garden-apiserver-ca-pem"
     - name: etcdCaPem
-      dataRef: "etcdcapem"
+      dataRef: "etcd-ca-pem"
     - name: etcdClientTlsPem
-      dataRef: "etcdclienttlspem"
+      dataRef: "etcd-client-tls-pem"
     - name: etcdClientTlsKeyPem
-      dataRef: "etcdclienttlskeypem"
+      dataRef: "etcd-client-tls-key-pem"
     - name: virtualGardenEndpoint
-      dataRef: "virtualgardenendpoint"
+      dataRef: "virtual-garden-endpoint"
+    - name: etcdUrl
+      dataRef: "etcd-url"
 
     targets:
-    - name: virtualGardenKubeconfig
-      target: "virtualgardenkubeconfig"
+    - name: virtualGardenCluster
+      target: "virtual-garden-cluster"
 EOF
 
 echo "Installation stored at ${INSTALLATION_PATH}"

--- a/hack/generate-cd.sh
+++ b/hack/generate-cd.sh
@@ -46,9 +46,12 @@ component-cli ca create "${CA_PATH}" \
 
 echo "> Extending resources.yaml: adding image of virtual-garden deployer"
 RESOURCES_BASE_PATH="$(mktemp -d)"
-cp -R ".landscaper/" "${RESOURCES_BASE_PATH}"
+
+# using .landscaper/resources yaml containing the blueprint and the required OCI images
+cp -a ".landscaper/." "${RESOURCES_BASE_PATH}"
 
 RESOURCES_FILE_PATH="${RESOURCES_BASE_PATH}/resources.yaml"
+
 cat << EOF >> ${RESOURCES_FILE_PATH}
 ---
 type: ociImage
@@ -67,3 +70,5 @@ mkdir -p ./gen
 CTF_PATH=${CTF_PATH} BASE_DEFINITION_PATH=${BASE_DEFINITION_PATH} CURRENT_COMPONENT_REPOSITORY=${REPO_CTX} RESOURCES_FILE_PATH=${RESOURCES_FILE_PATH} bash $SOURCE_PATH/.ci/component_descriptor
 
 component-cli ctf push --repo-ctx=${REPO_CTX} "${CTF_PATH}"
+
+echo "View the component descriptor with: component-cli component-archive remote get ${REPO_CTX} github.com/gardener/virtual-garden ${EFFECTIVE_VERSION}"

--- a/pkg/api/exports.go
+++ b/pkg/api/exports.go
@@ -18,10 +18,10 @@ package api
 type Exports struct {
 	VirtualGardenApiserverCaPem string `json:"virtualGardenApiserverCaPem,omitempty" yaml:"virtualGardenApiserverCaPem,omitempty"`
 	ServiceAccountKeyPem        string `json:"serviceAccountKeyPem,omitempty" yaml:"serviceAccountKeyPem,omitempty"`
-	EtcdCaPem             		string `json:"etcdCaPem,omitempty" yaml:"etcdCaPem,omitempty"`
-	EtcdClientTlsPem      		string `json:"etcdClientTlsPem,omitempty" yaml:"etcdClientTlsPem,omitempty"`
-	EtcdClientTlsKeyPem   		string `json:"etcdClientTlsKeyPem,omitempty" yaml:"etcdClientTlsKeyPem,omitempty"`
-	EtcdUrl   					string `json:"etcdUrl,omitempty" yaml:"etcdUrl,omitempty"`
-	KubeconfigYaml        		string `json:"kubeconfigYaml,omitempty" yaml:"kubeconfigYaml,omitempty"`
-	VirtualGardenEndpoint 		string `json:"virtualGardenEndpoint,omitempty" yaml:"virtualGardenEndpoint,omitempty"`
+	EtcdCaPem                   string `json:"etcdCaPem,omitempty" yaml:"etcdCaPem,omitempty"`
+	EtcdClientTlsPem            string `json:"etcdClientTlsPem,omitempty" yaml:"etcdClientTlsPem,omitempty"`
+	EtcdClientTlsKeyPem         string `json:"etcdClientTlsKeyPem,omitempty" yaml:"etcdClientTlsKeyPem,omitempty"`
+	EtcdUrl                     string `json:"etcdUrl,omitempty" yaml:"etcdUrl,omitempty"`
+	KubeconfigYaml              string `json:"kubeconfigYaml,omitempty" yaml:"kubeconfigYaml,omitempty"`
+	VirtualGardenEndpoint       string `json:"virtualGardenEndpoint,omitempty" yaml:"virtualGardenEndpoint,omitempty"`
 }

--- a/pkg/api/exports.go
+++ b/pkg/api/exports.go
@@ -14,13 +14,14 @@
 
 package api
 
-// Eports defines the structure for the exported data which might be consumed by other components.
+// Exports defines the structure for the exported data which might be consumed by other components.
 type Exports struct {
-	KubeApiserverCaPem    string `json:"kubeApiserverCaPem,omitempty" yaml:"kubeApiserverCaPem,omitempty"`
-	ServiceAccountKeyPem  string `json:"serviceAccountKeyPem,omitempty" yaml:"serviceAccountKeyPem,omitempty"`
-	EtcdCaPem             string `json:"etcdCaPem,omitempty" yaml:"etcdCaPem,omitempty"`
-	EtcdClientTlsPem      string `json:"etcdClientTlsPem,omitempty" yaml:"etcdClientTlsPem,omitempty"`
-	EtcdClientTlsKeyPem   string `json:"etcdClientTlsKeyPem,omitempty" yaml:"etcdClientTlsKeyPem,omitempty"`
-	KubeconfigYaml        string `json:"kubeconfigYaml,omitempty" yaml:"kubeconfigYaml,omitempty"`
-	VirtualGardenEndpoint string `json:"virtualGardenEndpoint,omitempty" yaml:"virtualGardenEndpoint,omitempty"`
+	VirtualGardenApiserverCaPem string `json:"virtualGardenApiserverCaPem,omitempty" yaml:"virtualGardenApiserverCaPem,omitempty"`
+	ServiceAccountKeyPem        string `json:"serviceAccountKeyPem,omitempty" yaml:"serviceAccountKeyPem,omitempty"`
+	EtcdCaPem             		string `json:"etcdCaPem,omitempty" yaml:"etcdCaPem,omitempty"`
+	EtcdClientTlsPem      		string `json:"etcdClientTlsPem,omitempty" yaml:"etcdClientTlsPem,omitempty"`
+	EtcdClientTlsKeyPem   		string `json:"etcdClientTlsKeyPem,omitempty" yaml:"etcdClientTlsKeyPem,omitempty"`
+	EtcdUrl   					string `json:"etcdUrl,omitempty" yaml:"etcdUrl,omitempty"`
+	KubeconfigYaml        		string `json:"kubeconfigYaml,omitempty" yaml:"kubeconfigYaml,omitempty"`
+	VirtualGardenEndpoint 		string `json:"virtualGardenEndpoint,omitempty" yaml:"virtualGardenEndpoint,omitempty"`
 }

--- a/pkg/api/imports.go
+++ b/pkg/api/imports.go
@@ -32,16 +32,16 @@ const (
 
 // Imports defines the structure for the required configuration values from other components.
 type Imports struct {
-	// Cluster is the kubeconfig of the hosting cluster into which the virtual garden shall be installed.
-	Cluster lsv1alpha1.Target `json:"cluster" yaml:"cluster"`
-	// HostingCluster contains settings for the hosting cluster that runs the virtual garden.
-	HostingCluster HostingCluster `json:"hostingCluster" yaml:"hostingCluster"`
+	// RuntimeCluster is the kubeconfig of the cluster into which the virtual garden shall be installed.
+	RuntimeCluster lsv1alpha1.Target `json:"runtimeCluster" yaml:"runtimeCluster"`
+	// RuntimeClusterSettings contains settings for the hosting cluster that runs the virtual garden.
+	RuntimeClusterSettings ClusterSettings `json:"runtimeClusterSettings" yaml:"runtimeClusterSettings"`
 	// VirtualGarden contains configuration for the virtual garden cluster.
 	VirtualGarden VirtualGarden `json:"virtualGarden" yaml:"virtualGarden"`
 }
 
-// HostingCluster contains settings for the hosting cluster that runs the virtual garden.
-type HostingCluster struct {
+// ClusterSettings contains settings for the hosting cluster that runs the virtual garden.
+type ClusterSettings struct {
 	// Namespace is a namespace in the hosting cluster into which the virtual garden shall be installed.
 	Namespace string `json:"namespace" yaml:"namespace"`
 	// InfrastructureProvider is the provider type of the underlying infrastructure of the hosting cluster.

--- a/pkg/api/loader/exports_test.go
+++ b/pkg/api/loader/exports_test.go
@@ -52,12 +52,12 @@ var _ = Describe("Exports", func() {
 			It("should succeed writing and reading", func() {
 				path := filepath.Join(dir, "imports.yaml")
 				exports := &api.Exports{
-					KubeApiserverCaPem:    "KubeApiserverCaPem-string",
-					EtcdCaPem:             "EtcdCaPem-string",
-					EtcdClientTlsPem:      "EtcdClientTlsPem-string",
-					EtcdClientTlsKeyPem:   "EtcdClientTlsKeyPem-string",
-					KubeconfigYaml:        "KubeconfigYaml-string",
-					VirtualGardenEndpoint: "VirtualGardenEndpoint-string",
+					VirtualGardenApiserverCaPem: "VirtualGardenApiserverCaPem-string",
+					EtcdCaPem:                   "EtcdCaPem-string",
+					EtcdClientTlsPem:            "EtcdClientTlsPem-string",
+					EtcdClientTlsKeyPem:         "EtcdClientTlsKeyPem-string",
+					KubeconfigYaml:              "KubeconfigYaml-string",
+					VirtualGardenEndpoint:       "VirtualGardenEndpoint-string",
 				}
 
 				err := ExportsToFile(exports, path)

--- a/pkg/api/loader/imports_test.go
+++ b/pkg/api/loader/imports_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Imports", func() {
 
 			It("should succeed reading and parsing the file (YAML)", func() {
 				path := filepath.Join(dir, "imports.yaml")
-				Expect(ioutil.WriteFile(path, []byte("virtualGarden: {}\nhostingCluster: {namespace: foo}\ncredentials: {}"), 0644)).To(Succeed())
+				Expect(ioutil.WriteFile(path, []byte("virtualGarden: {}\nruntimeClusterSettings: {namespace: foo}\ncredentials: {}"), 0644)).To(Succeed())
 
 				imports, err := ImportsFromFile(path)
 				Expect(err).NotTo(HaveOccurred())
@@ -71,7 +71,7 @@ var _ = Describe("Imports", func() {
 
 			It("should succeed reading and parsing the file (JSON)", func() {
 				path := filepath.Join(dir, "imports.json")
-				Expect(ioutil.WriteFile(path, []byte(`{"virtualGarden": {}, "hostingCluster": {"namespace": "foo"}, "credentials": {}}`), 0644)).To(Succeed())
+				Expect(ioutil.WriteFile(path, []byte(`{"virtualGarden": {}, "runtimeClusterSettings": {"namespace": "foo"}, "credentials": {}}`), 0644)).To(Succeed())
 
 				imports, err := ImportsFromFile(path)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/api/loader/imports_test.go
+++ b/pkg/api/loader/imports_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Imports", func() {
 				imports, err := ImportsFromFile(path)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(imports).To(Equal(&api.Imports{
-					HostingCluster: api.HostingCluster{Namespace: "foo"},
+					RuntimeClusterSettings: api.ClusterSettings{Namespace: "foo"},
 				}))
 			})
 
@@ -76,7 +76,7 @@ var _ = Describe("Imports", func() {
 				imports, err := ImportsFromFile(path)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(imports).To(Equal(&api.Imports{
-					HostingCluster: api.HostingCluster{Namespace: "foo"},
+					RuntimeClusterSettings: api.ClusterSettings{Namespace: "foo"},
 				}))
 			})
 		})

--- a/pkg/api/validation/imports.go
+++ b/pkg/api/validation/imports.go
@@ -27,8 +27,8 @@ import (
 func ValidateImports(obj *api.Imports) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, ValidateCluster(&obj.Cluster, field.NewPath("cluster"))...)
-	allErrs = append(allErrs, ValidateHostingCluster(&obj.HostingCluster, field.NewPath("hostingCluster"))...)
+	allErrs = append(allErrs, ValidateCluster(&obj.RuntimeCluster, field.NewPath("cluster"))...)
+	allErrs = append(allErrs, ValidateHostingCluster(&obj.RuntimeClusterSettings, field.NewPath("hostingCluster"))...)
 	allErrs = append(allErrs, ValidateVirtualGarden(&obj.VirtualGarden, field.NewPath("virtualGarden"))...)
 
 	return allErrs
@@ -55,8 +55,8 @@ func ValidateCluster(obj *lsv1alpha1.Target, fldPath *field.Path) field.ErrorLis
 	return allErrs
 }
 
-// ValidateHostingCluster validates a HostingCluster object.
-func ValidateHostingCluster(obj *api.HostingCluster, fldPath *field.Path) field.ErrorList {
+// ValidateHostingCluster validates a ClusterSettings object.
+func ValidateHostingCluster(obj *api.ClusterSettings, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(obj.Namespace) == 0 {

--- a/pkg/api/validation/imports_test.go
+++ b/pkg/api/validation/imports_test.go
@@ -37,14 +37,14 @@ var _ = Describe("Imports", func() {
 
 		BeforeEach(func() {
 			obj = &api.Imports{
-				Cluster: lsv1alpha1.Target{
+				RuntimeCluster: lsv1alpha1.Target{
 					Spec: lsv1alpha1.TargetSpec{
 						Configuration: lsv1alpha1.AnyJSON{
 							RawMessage: json.RawMessage(`{"config":{"kubeconfig":"x"}}`),
 						},
 					},
 				},
-				HostingCluster: api.HostingCluster{
+				RuntimeClusterSettings: api.ClusterSettings{
 					Namespace:              "foo",
 					InfrastructureProvider: "gcp",
 				},
@@ -69,9 +69,9 @@ var _ = Describe("Imports", func() {
 
 		Context("hosting cluster", func() {
 			It("should fail for an invalid configuration", func() {
-				obj.Cluster = lsv1alpha1.Target{}
-				obj.HostingCluster.Namespace = ""
-				obj.HostingCluster.InfrastructureProvider = ""
+				obj.RuntimeCluster = lsv1alpha1.Target{}
+				obj.RuntimeClusterSettings.Namespace = ""
+				obj.RuntimeClusterSettings.InfrastructureProvider = ""
 
 				Expect(ValidateImports(obj)).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/virtualgarden/etcd_certificates.go
+++ b/pkg/virtualgarden/etcd_certificates.go
@@ -86,6 +86,7 @@ func (o *operation) deployETCDClientCertificate(ctx context.Context, caCertifica
 	}
 
 	o.exports.EtcdClientTlsKeyPem = string(cert.PrivateKeyPEM)
+	o.exports.EtcdUrl = string(cert.PrivateKeyPEM)
 	o.exports.EtcdClientTlsPem = string(cert.CertificatePEM)
 
 	return cert, clientCertChecksum, err

--- a/pkg/virtualgarden/etcd_certificates.go
+++ b/pkg/virtualgarden/etcd_certificates.go
@@ -86,7 +86,6 @@ func (o *operation) deployETCDClientCertificate(ctx context.Context, caCertifica
 	}
 
 	o.exports.EtcdClientTlsKeyPem = string(cert.PrivateKeyPEM)
-	o.exports.EtcdUrl = string(cert.PrivateKeyPEM)
 	o.exports.EtcdClientTlsPem = string(cert.CertificatePEM)
 
 	return cert, clientCertChecksum, err

--- a/pkg/virtualgarden/etcd_service.go
+++ b/pkg/virtualgarden/etcd_service.go
@@ -16,6 +16,7 @@ package virtualgarden
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gardener/gardener/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -61,6 +62,12 @@ func (o *operation) deployETCDService(ctx context.Context, role string) error {
 		})
 		return nil
 	})
+
+	// export the etcd Url
+	if role == ETCDRoleMain {
+		o.exports.EtcdUrl = fmt.Sprintf("%s.%s.svc:%d", service.Name, service.Namespace, etcdServiceClientPort)
+	}
+
 	return err
 }
 

--- a/pkg/virtualgarden/kube_api_server_certificates.go
+++ b/pkg/virtualgarden/kube_api_server_certificates.go
@@ -125,7 +125,7 @@ func (o *operation) deployKubeApiServerApiServerCACertificate(ctx context.Contex
 		return nil, err
 	}
 
-	o.exports.KubeApiserverCaPem = string(cert.CertificatePEM)
+	o.exports.VirtualGardenApiserverCaPem = string(cert.CertificatePEM)
 
 	checksums[ChecksumKeyKubeAPIServerCA] = checksum
 	return cert, err

--- a/pkg/virtualgarden/kube_api_server_certificates_test.go
+++ b/pkg/virtualgarden/kube_api_server_certificates_test.go
@@ -107,8 +107,8 @@ var _ = Describe("Api Server create certificates test", func() {
 
 func getImportsApiServerCertificatesTest() api.Imports {
 	return api.Imports{
-		Cluster:        lsv1alpha1.Target{},
-		HostingCluster: api.HostingCluster{},
+		RuntimeCluster:         lsv1alpha1.Target{},
+		RuntimeClusterSettings: api.ClusterSettings{},
 		VirtualGarden: api.VirtualGarden{
 			ETCD: nil,
 			KubeAPIServer: &api.KubeAPIServer{

--- a/pkg/virtualgarden/kube_api_server_configmaps_test.go
+++ b/pkg/virtualgarden/kube_api_server_configmaps_test.go
@@ -95,8 +95,8 @@ var _ = Describe("Api Server create configmaps test", func() {
 
 func getImportsForApiServerConfigMapsTest() api.Imports {
 	return api.Imports{
-		Cluster:        lsv1alpha1.Target{},
-		HostingCluster: api.HostingCluster{},
+		RuntimeCluster:         lsv1alpha1.Target{},
+		RuntimeClusterSettings: api.ClusterSettings{},
 		VirtualGarden: api.VirtualGarden{
 			ETCD: nil,
 			KubeAPIServer: &api.KubeAPIServer{

--- a/pkg/virtualgarden/kube_api_server_deployment_controller_manager_test.go
+++ b/pkg/virtualgarden/kube_api_server_deployment_controller_manager_test.go
@@ -88,8 +88,8 @@ var _ = Describe("Api Server deployment test", func() {
 
 func getImportsForControllerManagerDeploymentTest() *api.Imports {
 	return &api.Imports{
-		Cluster:        lsv1alpha1.Target{},
-		HostingCluster: api.HostingCluster{},
+		RuntimeCluster:         lsv1alpha1.Target{},
+		RuntimeClusterSettings: api.ClusterSettings{},
 		VirtualGarden: api.VirtualGarden{
 			ETCD: nil,
 			KubeAPIServer: &api.KubeAPIServer{

--- a/pkg/virtualgarden/kube_api_server_deployments_test.go
+++ b/pkg/virtualgarden/kube_api_server_deployments_test.go
@@ -98,8 +98,8 @@ var _ = Describe("Api Server deployment test", func() {
 
 func getImportsForDeploymentTest() *api.Imports {
 	return &api.Imports{
-		Cluster:        lsv1alpha1.Target{},
-		HostingCluster: api.HostingCluster{},
+		RuntimeCluster:         lsv1alpha1.Target{},
+		RuntimeClusterSettings: api.ClusterSettings{},
 		VirtualGarden: api.VirtualGarden{
 			ETCD: nil,
 			KubeAPIServer: &api.KubeAPIServer{

--- a/pkg/virtualgarden/kube_api_server_misc_test.go
+++ b/pkg/virtualgarden/kube_api_server_misc_test.go
@@ -130,8 +130,8 @@ var _ = Describe("Api Server misc test", func() {
 
 func getImportsForMiscTest() *api.Imports {
 	return &api.Imports{
-		Cluster:        lsv1alpha1.Target{},
-		HostingCluster: api.HostingCluster{},
+		RuntimeCluster:         lsv1alpha1.Target{},
+		RuntimeClusterSettings: api.ClusterSettings{},
 		VirtualGarden: api.VirtualGarden{
 			ETCD: nil,
 			KubeAPIServer: &api.KubeAPIServer{

--- a/pkg/virtualgarden/kube_api_server_podautoscaling_test.go
+++ b/pkg/virtualgarden/kube_api_server_podautoscaling_test.go
@@ -151,8 +151,8 @@ func getHVPASettings() *api.HvpaConfig {
 
 func getImportsForHvpa() api.Imports {
 	return api.Imports{
-		Cluster:        lsv1alpha1.Target{},
-		HostingCluster: api.HostingCluster{},
+		RuntimeCluster:         lsv1alpha1.Target{},
+		RuntimeClusterSettings: api.ClusterSettings{},
 		VirtualGarden: api.VirtualGarden{
 			ETCD: nil,
 			KubeAPIServer: &api.KubeAPIServer{

--- a/pkg/virtualgarden/kube_api_server_secrets_test.go
+++ b/pkg/virtualgarden/kube_api_server_secrets_test.go
@@ -104,8 +104,8 @@ var _ = Describe("Api Server create secrets test", func() {
 
 func getImportsForApiServerSecretsTest() api.Imports {
 	return api.Imports{
-		Cluster:        lsv1alpha1.Target{},
-		HostingCluster: api.HostingCluster{},
+		RuntimeCluster:         lsv1alpha1.Target{},
+		RuntimeClusterSettings: api.ClusterSettings{},
 		VirtualGarden: api.VirtualGarden{
 			ETCD: nil,
 			KubeAPIServer: &api.KubeAPIServer{

--- a/pkg/virtualgarden/operation.go
+++ b/pkg/virtualgarden/operation.go
@@ -82,7 +82,7 @@ func NewOperation(
 		imageRefs: *imageRefs,
 	}
 
-	infrastructureProvider, err := provider.NewInfrastructureProvider(imports.HostingCluster.InfrastructureProvider)
+	infrastructureProvider, err := provider.NewInfrastructureProvider(imports.RuntimeClusterSettings.InfrastructureProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virtualgarden/operation_test.go
+++ b/pkg/virtualgarden/operation_test.go
@@ -31,8 +31,8 @@ var _ = Describe("Operation", func() {
 				log       = logrus.New()
 				namespace = "foo"
 				imports   = &api.Imports{
-					HostingCluster: api.HostingCluster{InfrastructureProvider: api.InfrastructureProviderGCP},
-					VirtualGarden:  api.VirtualGarden{},
+					RuntimeClusterSettings: api.ClusterSettings{InfrastructureProvider: api.InfrastructureProviderGCP},
+					VirtualGarden:          api.VirtualGarden{},
 				}
 				imageRefs = &api.ImageRefs{
 					ETCDImage:                  "eu.gcr.io/sap-se-gcr-k8s-public/quay_io/coreos/etcd:v3.3.17",


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
- export the etcd-main URL 
- harmonize the field names of the blueprint
- fixed the component descriptor generator (did not add the blueprint & OCI images)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
the virtual garden component exports the virtual garden etcd-main url
```
