### PR TITLE
Update image versions

### DIFF
--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -30,7 +30,7 @@ name: kube-apiserver
 relation: local
 access:
   type: ociRegistry
-  imageReference: k8s.gcr.io/kube-apiserver:v1.19.15
+  imageReference: k8s.gcr.io/kube-apiserver:v1.20.15
 ...
 ---
 type: ociImage
@@ -38,5 +38,5 @@ name: kube-controller-manager
 relation: local
 access:
   type: ociRegistry
-  imageReference: k8s.gcr.io/kube-controller-manager:v1.19.15
+  imageReference: k8s.gcr.io/kube-controller-manager:v1.20.15
 ...


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR sets the versions of the following images in the component descriptor:
- kube-apiserver to version v1.20.15
- kube-controller-manager to version v1.20.15

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The other two images in the resources.yaml have the same version as in [LSS](https://github.wdf.sap.corp/kubernetes/landscape-setup/blob/748e9c8b10be1a64130a4038fedb68ddd40427ad/components/garden/virtual/charts/etcd/values.yaml#L4-L14):
- eu.gcr.io/gardener-project/gardener/etcd:v3.4.13
- eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.11.1

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
