### PR TITLE
external references relation corrected

### DIFF
--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -11,7 +11,7 @@ input:
 ---
 type: ociImage
 name: etcd
-relation: local
+relation: external
 access:
   type: ociRegistry
   imageReference: eu.gcr.io/gardener-project/gardener/etcd:v3.4.13
@@ -19,7 +19,7 @@ access:
 ---
 type: ociImage
 name: etcd-backup-restore
-relation: local
+relation: external
 access:
   type: ociRegistry
   imageReference: eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.11.1
@@ -27,7 +27,7 @@ access:
 ---
 type: ociImage
 name: kube-apiserver
-relation: local
+relation: external
 access:
   type: ociRegistry
   imageReference: k8s.gcr.io/kube-apiserver:v1.20.15
@@ -35,7 +35,7 @@ access:
 ---
 type: ociImage
 name: kube-controller-manager
-relation: local
+relation: external
 access:
   type: ociRegistry
   imageReference: k8s.gcr.io/kube-controller-manager:v1.20.15


### PR DESCRIPTION
External image references were tagged local which results in a version mismatch in component descriptor, e.g.
```yaml
name: etcd
      version: v0.4.0 
[...]
        imageReference: >-
          eu.gcr.io/sap-se-gcr-k8s-public/eu_gcr_io/gardener-project/gardener/etcd:v3.4.13-mod1 

```

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     delivery
"/kind" identifiers:     bug

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
