### PR TITLE
update apiserver flags for kube-apiserver v1.20.x

### DIFF
--- a/pkg/virtualgarden/kube_api_server_deployments.go
+++ b/pkg/virtualgarden/kube_api_server_deployments.go
@@ -301,6 +301,8 @@ func (o *operation) getAPIServerCommand() []string {
 	command = append(command, "--requestheader-username-headers=X-Remote-User")
 	command = append(command, "--secure-port=443")
 	command = append(command, "--service-account-key-file=/srv/kubernetes/service-account-key/service_account.key")
+	command = append(command, "--service-account-signing-key-file=/srv/kubernetes/service-account-key/service_account.key")
+	command = append(command, fmt.Sprintf("--service-account-issuer=https://gardener.%s", o.imports.VirtualGarden.KubeAPIServer.DnsAccessDomain))
 	command = append(command, "--service-cluster-ip-range=100.64.0.0/13")
 	command = append(command, "--shutdown-delay-duration=20s")
 	command = append(command, "--tls-cert-file=/srv/kubernetes/apiserver/tls.crt")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:

kube-apiserver flags were missing for version v1.20.x

```
Error: [service-account-issuer is a required flag, --service-account-signing-key-file and --service-account-issuer are required flags]
```

Tried to update it accordingly to the lss version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
