### PR TITLE
Add version field to external resources in component descriptor

### DIFF
--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -11,6 +11,7 @@ input:
 ---
 type: ociImage
 name: etcd
+version: v3.14.13
 relation: external
 access:
   type: ociRegistry
@@ -20,6 +21,7 @@ access:
 type: ociImage
 name: etcd-backup-restore
 relation: external
+version: v0.11.1
 access:
   type: ociRegistry
   imageReference: eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.11.1
@@ -27,6 +29,7 @@ access:
 ---
 type: ociImage
 name: kube-apiserver
+version: v1.20.15
 relation: external
 access:
   type: ociRegistry
@@ -35,6 +38,7 @@ access:
 ---
 type: ociImage
 name: kube-controller-manager
+version: v1.20.15
 relation: external
 access:
   type: ociRegistry


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:

External resources in component descriptor need to have a version field.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
