### PR TITLE
switch from v1beta1 to v1 for CustomResourceDefinition

### DIFF
--- a/cmd/virtual-garden/app/virtual_garden.go
+++ b/cmd/virtual-garden/app/virtual_garden.go
@@ -32,7 +32,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
@@ -180,7 +180,7 @@ func NewClientFromKubeconfig(kubeconfig []byte) (client.Client, error) {
 	utilruntime.Must(kubernetesscheme.AddToScheme(scheme))
 	utilruntime.Must(hvpav1alpha1.AddToScheme(scheme))
 	utilruntime.Must(autoscalingv1beta2.AddToScheme(scheme))
-	utilruntime.Must(apiextensionsv1beta1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 
 	return client.New(restConfig, client.Options{Scheme: scheme})
 }

--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -19,7 +19,7 @@ set -e
 CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 
-curl -sfL "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" | sh -s -- -b $(go env GOPATH)/bin v1.32.2
+curl -sfL "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" | sh -s -- -b $(go env GOPATH)/bin v1.32.2
 
 GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 

--- a/pkg/virtualgarden/crd_util.go
+++ b/pkg/virtualgarden/crd_util.go
@@ -7,7 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -65,7 +66,7 @@ func DeployVPACRD(ctx context.Context, c client.Client) error {
 	return err
 }
 
-func waitToBeEstablished(ctx context.Context, c client.Client, crd *v1beta1.CustomResourceDefinition) error {
+func waitToBeEstablished(ctx context.Context, c client.Client, crd *v1.CustomResourceDefinition) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
@@ -79,7 +80,7 @@ func waitToBeEstablished(ctx context.Context, c client.Client, crd *v1beta1.Cust
 
 		conditions := crd.Status.Conditions
 		for _, condition := range conditions {
-			if condition.Type == v1beta1.Established && condition.Status == v1beta1.ConditionTrue {
+			if condition.Type == v1.Established && condition.Status == v1.ConditionTrue {
 				return true, nil
 			}
 		}
@@ -96,8 +97,8 @@ func DeleteHPVACRD(ctx context.Context, c client.Client) error {
 }
 
 // loadCRD loads the CRD.
-func loadCRD(crdBytes []byte) (*v1beta1.CustomResourceDefinition, error) {
-	crd := &v1beta1.CustomResourceDefinition{}
+func loadCRD(crdBytes []byte) (*v1.CustomResourceDefinition, error) {
+	crd := &v1.CustomResourceDefinition{}
 	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(crdBytes), 32)
 	err := decoder.Decode(crd)
 	if err != nil {
@@ -107,8 +108,8 @@ func loadCRD(crdBytes []byte) (*v1beta1.CustomResourceDefinition, error) {
 	return crd, nil
 }
 
-func emptyVPACRD() *v1beta1.CustomResourceDefinition {
-	return &v1beta1.CustomResourceDefinition{
+func emptyVPACRD() *v1.CustomResourceDefinition {
+	return &v1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "verticalpodautoscalers.autoscaling.k8s.io",
 		},

--- a/pkg/virtualgarden/hvpa_crd.go
+++ b/pkg/virtualgarden/hvpa_crd.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	_ "embed"
 
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"github.com/gardener/virtual-garden/pkg/api/helper"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -39,7 +40,7 @@ func (o *operation) checkHVPACRD(ctx context.Context) error {
 }
 
 // getHVPACRD return the HVPA CRD.
-func (o *operation) getHVPACRD(ctx context.Context) (*v1beta1.CustomResourceDefinition, error) {
+func (o *operation) getHVPACRD(ctx context.Context) (*v1.CustomResourceDefinition, error) {
 	hvpaCrd := emptyHVPACRD()
 	err := o.client.Get(ctx, client.ObjectKeyFromObject(hvpaCrd), hvpaCrd)
 	if err != nil {
@@ -49,8 +50,8 @@ func (o *operation) getHVPACRD(ctx context.Context) (*v1beta1.CustomResourceDefi
 	return hvpaCrd, nil
 }
 
-func emptyHVPACRD() *v1beta1.CustomResourceDefinition {
-	return &v1beta1.CustomResourceDefinition{
+func emptyHVPACRD() *v1.CustomResourceDefinition {
+	return &v1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "hvpas.autoscaling.k8s.io",
 		},

--- a/test/utils/localenvtest/environment.go
+++ b/test/utils/localenvtest/environment.go
@@ -14,7 +14,7 @@ import (
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
@@ -79,7 +79,7 @@ func (e *Environment) Start() (client.Client, error) {
 	utilruntime.Must(hvpav1alpha1.AddToScheme(scheme))
 	utilruntime.Must(autoscalingv1beta2.AddToScheme(scheme))
 	utilruntime.Must(apiextensions.AddToScheme(scheme))
-	utilruntime.Must(apiextensionsv1beta1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(policyv1.AddToScheme(scheme))
 
 	fakeClient, err := client.New(restConfig, client.Options{Scheme: scheme})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area kubernetes-api
/kind bug

**What this PR does / why we need it**:

Since Kubernetes 1.22. the CustomResourceDefinition API is no longer available under GV "apiextensions.k8s.io/v1beta1".
Instead GV "apiextensions.k8s.io/v1" has to be used.

See https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22

**Which issue(s) this PR fixes**:

It was no longer possible to delete the virtual garden on kubernetes clusters ver >= 1.22. because of this issue.


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Fix the deletion operation on Kubernetes versions >= 1.22.
```
