### PR TITLE
make the encrypted resources in the encryption configuration configurable

### DIFF
--- a/.landscaper/blueprint/blueprint.yaml
+++ b/.landscaper/blueprint/blueprint.yaml
@@ -194,6 +194,13 @@ imports:
               type: integer
             profiling:
               type: boolean
+            encryptionConfig:
+              type: object
+              properties:
+                resources:
+                  type: array
+                  items:
+                    type: string
         deleteNamespace:
           type: boolean
         priorityClassName:

--- a/pkg/api/imports.go
+++ b/pkg/api/imports.go
@@ -126,6 +126,8 @@ type KubeAPIServer struct {
 	MaxMutatingRequestsInflight *int `json:"maxMutatingRequestsInflight,omitempty" yaml:"maxMutatingRequestsInflight,omitempty"`
 
 	Profiling bool `json:"profiling,omitempty" yaml:"profiling,omitempty"`
+
+	EncryptionConfig EncryptionConfig `json:"encryptionConfig,omitempty" yaml:"encryptionConfig,omitempty"`
 }
 
 func (r *KubeAPIServer) GetMaxRequestsInflight(defaultValue int) int {
@@ -200,3 +202,8 @@ type Credentials struct {
 
 // InfrastructureProviderType is a string alias.
 type InfrastructureProviderType string
+
+// EncryptionConfig configures the kubernetes EncryptionConfiguration used by the Kube API server.
+type EncryptionConfig struct {
+	Resources []string `json:"resources" yaml:"resources"`
+}

--- a/pkg/virtualgarden/kube_api_server_secrets.go
+++ b/pkg/virtualgarden/kube_api_server_secrets.go
@@ -411,6 +411,10 @@ func (o *operation) generateNewEncryptionConfig() ([]byte, error) {
 		},
 	}
 
+	if len(o.imports.VirtualGarden.KubeAPIServer.EncryptionConfig.Resources) > 0 {
+		encryptionConfig.Resources[0].Resources = o.imports.VirtualGarden.KubeAPIServer.EncryptionConfig.Resources
+	}
+
 	return yaml.Marshal(&encryptionConfig)
 }
 


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

This PR makes the list of resources that shall be stored encrypted in etcd configurable. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The list of resources that shall be stored encrypted in etcd is now configurable. 
```
