### PR TITLE
Update virtual garden

### DIFF
--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -11,7 +11,7 @@ input:
 ---
 type: ociImage
 name: etcd
-version: v3.14.13
+version: v3.4.13
 relation: external
 access:
   type: ociRegistry
@@ -29,18 +29,18 @@ access:
 ---
 type: ociImage
 name: kube-apiserver
-version: v1.20.15
+version: v1.22.15
 relation: external
 access:
   type: ociRegistry
-  imageReference: k8s.gcr.io/kube-apiserver:v1.21.14
+  imageReference: k8s.gcr.io/kube-apiserver:v1.22.15
 ...
 ---
 type: ociImage
 name: kube-controller-manager
-version: v1.20.15
+version: v1.22.15
 relation: external
 access:
   type: ociRegistry
-  imageReference: k8s.gcr.io/kube-controller-manager:v1.21.14
+  imageReference: k8s.gcr.io/kube-controller-manager:v1.22.15
 ...

--- a/example/resolved-component-descriptor.json
+++ b/example/resolved-component-descriptor.json
@@ -52,21 +52,21 @@
           },
           {
             "name": "kube-apiserver",
-            "version": "v1.19.15",
+            "version": "v1.22.15",
             "type": "ociImage",
             "relation": "external",
             "access": {
-              "imageReference": "k8s.gcr.io/kube-apiserver:v1.19.15",
+              "imageReference": "k8s.gcr.io/kube-apiserver:v1.22.15",
               "type": "ociRegistry"
             }
           },
           {
             "name": "kube-controller-manager",
-            "version": "v1.19.15",
+            "version": "v1.22.15",
             "type": "ociImage",
             "relation": "external",
             "access": {
-              "imageReference": "k8s.gcr.io/kube-controller-manager:v1.19.15",
+              "imageReference": "k8s.gcr.io/kube-controller-manager:v1.22.15",
               "type": "ociRegistry"
             }
           },

--- a/pkg/virtualgarden/kube_api_server_deployments.go
+++ b/pkg/virtualgarden/kube_api_server_deployments.go
@@ -303,7 +303,7 @@ func (o *operation) getAPIServerCommand() []string {
 	command = append(command, "--service-cluster-ip-range=100.64.0.0/13")
 	command = append(command, "--shutdown-delay-duration=20s")
 	command = append(command, "--tls-cert-file=/srv/kubernetes/apiserver/tls.crt")
-	command = append(command, "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA")
+	command = append(command, "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")
 	command = append(command, "--tls-private-key-file=/srv/kubernetes/apiserver/tls.key")
 	if o.isSNIEnabled() {
 		command = append(command, fmt.Sprintf("--tls-sni-cert-key=/srv/kubernetes/sni-tls/tls.crt,/srv/kubernetes/sni-tls/tls.key:%s", o.getSNIHostname()))

--- a/test/e2e/resources/component-descriptor.json
+++ b/test/e2e/resources/component-descriptor.json
@@ -42,21 +42,21 @@
           },
           {
             "name": "kube-apiserver",
-            "version": "v1.19.15",
+            "version": "v1.22.15",
             "type": "ociImage",
             "relation": "external",
             "access": {
-              "imageReference": "k8s.gcr.io/kube-apiserver:v1.19.15",
+              "imageReference": "k8s.gcr.io/kube-apiserver:v1.22.15",
               "type": "ociRegistry"
             }
           },
           {
             "name": "kube-controller-manager",
-            "version": "v1.19.15",
+            "version": "v1.22.15",
             "type": "ociImage",
             "relation": "external",
             "access": {
-              "imageReference": "k8s.gcr.io/kube-controller-manager:v1.19.15",
+              "imageReference": "k8s.gcr.io/kube-controller-manager:v1.22.15",
               "type": "ociRegistry"
             }
           }

--- a/test/e2e/resources/imports.yaml
+++ b/test/e2e/resources/imports.yaml
@@ -1,4 +1,4 @@
-cluster:
+runtimeCluster:
   apiVersion: "landscaper.gardener.cloud/v1alpha1"
   kind: Target
   metadata:
@@ -12,7 +12,7 @@ cluster:
         kind: Config
 #       ... <please insert your kubeconfig here>
 
-hostingCluster:
+runtimeClusterSettings:
   namespace: garden
   infrastructureProvider: gcp # aws|gcp|alicloud
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:

This pull request updates the version of the `k8s.gcr.io/kube-apiserver` and `k8s.gcr.io/kube-controller-manager` images to `v1.22.15`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- update of kube-apiserver and kube-controller-manager to version v1.22.15
```
